### PR TITLE
Update lambda deployment workflow for staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - staging
 
 jobs:
   deploy:
@@ -20,7 +21,12 @@ jobs:
         AWS_REGION: ${{ secrets.AWS_REGION }}
       run: |
         if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-          FUNCTION_NAME="agent-lambda-function"
+          FUNCTION_NAME="prod-ajentify-api"
+        elif [ "${{ github.ref }}" == "refs/heads/staging" ]; then
+          FUNCTION_NAME="staging-ajentify-api"
+        else
+          echo "Branch ${{ github.ref }} is not configured for deployment" >&2
+          exit 1
         fi
 
         cd src


### PR DESCRIPTION
## Summary
- trigger lambda deployments on `main` and `staging`
- deploy to `prod-ajentify-api` when pushing `main`
- deploy to `staging-ajentify-api` when pushing `staging`

## Testing
- `python -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'AWS')*

------
https://chatgpt.com/codex/tasks/task_e_6843fbd1696c8327b6bf853fee2e4e5f