### PR TITLE
Add Jira OAuth 2.0 integration and proxy

### DIFF
--- a/src/RequestHandlers/Jira/JiraHandlers.py
+++ b/src/RequestHandlers/Jira/JiraHandlers.py
@@ -1,0 +1,109 @@
+import json
+import os
+import time
+import requests
+from pydantic import BaseModel
+from AWS.Lambda import LambdaEvent
+from AWS.Cognito import CognitoUser
+from AWS.CloudWatchLogs import get_logger
+from Models import Integration, User
+from Services import JiraService
+
+logger = get_logger(log_level=os.environ.get("LOG_LEVEL", "INFO"))
+
+JIRA_TOKEN_URL = "https://auth.atlassian.com/oauth/token"
+ACCESSIBLE_RESOURCES_URL = "https://api.atlassian.com/oauth/token/accessible-resources"
+
+
+class JiraProxyResponse(BaseModel):
+    data: dict
+
+
+def jira_auth_code_handler(lambda_event: LambdaEvent, user: CognitoUser) -> Integration.Integration:
+    body = json.loads(lambda_event.body)
+    code = body.get("code")
+    if not code:
+        raise Exception("code is required", 400)
+
+    db_user = User.get_user(user.sub)
+    if len(db_user.organizations) == 0:
+        raise Exception("User is not a member of any organizations", 400)
+    org_id = db_user.organizations[0]
+
+    payload = {
+        "grant_type": "authorization_code",
+        "client_id": os.environ["JIRA_CLIENT_ID"],
+        "client_secret": os.environ["JIRA_CLIENT_SECRET"],
+        "code": code,
+        "redirect_uri": os.environ["JIRA_REDIRECT_URI"],
+    }
+    resp = requests.post(JIRA_TOKEN_URL, json=payload)
+    if resp.status_code != 200:
+        raise Exception("Failed to exchange Jira auth code", resp.status_code)
+    data = resp.json()
+
+    integration_config = {
+        "access_token": data["access_token"],
+        "refresh_token": data["refresh_token"],
+        "expires_in": data.get("expires_in"),
+        "scope": data.get("scope"),
+        "expires_at": int(time.time()) + data.get("expires_in", 0),
+    }
+
+    res = requests.get(
+        ACCESSIBLE_RESOURCES_URL,
+        headers={"Authorization": f"Bearer {data['access_token']}"},
+    )
+    if res.status_code == 200:
+        resources = res.json()
+        if resources:
+            integration_config["cloud_id"] = resources[0].get("id")
+            integration_config["resource_url"] = resources[0].get("url")
+
+    jira_integration = None
+    for integ in Integration.get_integrations_in_org(org_id):
+        if integ.type == "jira":
+            jira_integration = integ
+            break
+
+    if jira_integration:
+        jira_integration.integration_config = integration_config
+        Integration.save_integration(jira_integration)
+    else:
+        jira_integration = Integration.create_integration(
+            org_id=org_id, type="jira", integration_config=integration_config
+        )
+
+    return jira_integration
+
+
+def jira_projects_handler(lambda_event: LambdaEvent, user: CognitoUser) -> JiraProxyResponse:
+    db_user = User.get_user(user.sub)
+    data = JiraService.list_projects(db_user)
+    return JiraProxyResponse(data=data)
+
+
+def jira_create_issue_handler(lambda_event: LambdaEvent, user: CognitoUser) -> JiraProxyResponse:
+    db_user = User.get_user(user.sub)
+    issue_data = json.loads(lambda_event.body)
+    data = JiraService.create_issue(db_user, issue_data)
+    return JiraProxyResponse(data=data)
+
+
+def jira_get_issues_handler(lambda_event: LambdaEvent, user: CognitoUser) -> JiraProxyResponse:
+    db_user = User.get_user(user.sub)
+    jql = None
+    if lambda_event.queryStringParameters:
+        jql = lambda_event.queryStringParameters.get("jql")
+    data = JiraService.search_issues(db_user, jql=jql)
+    return JiraProxyResponse(data=data)
+
+
+def jira_update_issue_handler(lambda_event: LambdaEvent, user: CognitoUser) -> JiraProxyResponse:
+    db_user = User.get_user(user.sub)
+    issue_id = lambda_event.requestParameters.get("issue_id")
+    if not issue_id:
+        raise Exception("issue_id is required", 400)
+    body = json.loads(lambda_event.body)
+    data = JiraService.update_issue(db_user, issue_id, body)
+    return JiraProxyResponse(data=data)

--- a/src/RequestHandlers/Jira/JiraHandlers.py
+++ b/src/RequestHandlers/Jira/JiraHandlers.py
@@ -28,7 +28,11 @@ def jira_auth_code_handler(lambda_event: LambdaEvent, user: CognitoUser) -> Inte
     db_user = User.get_user(user.sub)
     if len(db_user.organizations) == 0:
         raise Exception("User is not a member of any organizations", 400)
-    org_id = db_user.organizations[0]
+    org_id = lambda_event.queryStringParameters.get("org_id")
+    if not org_id:
+        org_id = db_user.organizations[0]
+    if org_id not in [org_id for org_id in db_user.organizations]:
+        raise Exception("User is not a member of the specified organization", 403)
 
     payload = {
         "grant_type": "authorization_code",

--- a/src/Services/JiraService.py
+++ b/src/Services/JiraService.py
@@ -1,0 +1,87 @@
+import os
+import time
+import requests
+from AWS.CloudWatchLogs import get_logger
+from Models import Integration, User
+
+logger = get_logger(log_level=os.environ.get("LOG_LEVEL", "INFO"))
+
+JIRA_TOKEN_URL = "https://auth.atlassian.com/oauth/token"
+ACCESSIBLE_RESOURCES_URL = "https://api.atlassian.com/oauth/token/accessible-resources"
+
+
+def _get_jira_integration(user: User.User) -> Integration.Integration:
+    if len(user.organizations) == 0:
+        raise Exception("User is not a member of any organizations", 400)
+    org_id = user.organizations[0]
+    integrations = Integration.get_integrations_in_org(org_id)
+    for integration in integrations:
+        if integration.type == "jira":
+            return integration
+    raise Exception("Jira integration not found", 404)
+
+
+def _refresh_token(integration: Integration.Integration) -> Integration.Integration:
+    refresh_token = integration.integration_config.get("refresh_token")
+    payload = {
+        "grant_type": "refresh_token",
+        "client_id": os.environ["JIRA_CLIENT_ID"],
+        "client_secret": os.environ["JIRA_CLIENT_SECRET"],
+        "refresh_token": refresh_token,
+    }
+    resp = requests.post(JIRA_TOKEN_URL, json=payload)
+    if resp.status_code != 200:
+        raise Exception("Failed to refresh Jira token", resp.status_code)
+    data = resp.json()
+    integration.integration_config.update(
+        {
+            "access_token": data["access_token"],
+            "refresh_token": data["refresh_token"],
+            "expires_in": data.get("expires_in"),
+            "scope": data.get("scope"),
+            "expires_at": int(time.time()) + data.get("expires_in", 0),
+        }
+    )
+    Integration.save_integration(integration)
+    return integration
+
+
+def _ensure_token(integration: Integration.Integration) -> str:
+    expires_at = integration.integration_config.get("expires_at")
+    if expires_at and expires_at <= int(time.time()):
+        integration = _refresh_token(integration)
+    return integration.integration_config.get("access_token")
+
+
+def jira_api_request(user: User.User, method: str, path: str, **kwargs):
+    integration = _get_jira_integration(user)
+    access_token = _ensure_token(integration)
+    cloud_id = integration.integration_config.get("cloud_id")
+    if not cloud_id:
+        raise Exception("No Jira cloud id stored", 400)
+    url = f"https://api.atlassian.com/ex/jira/{cloud_id}{path}"
+    headers = kwargs.pop("headers", {})
+    headers.update({"Authorization": f"Bearer {access_token}", "Accept": "application/json"})
+    resp = requests.request(method, url, headers=headers, **kwargs)
+    if resp.status_code >= 400:
+        raise Exception(f"Jira API error: {resp.text}", resp.status_code)
+    if resp.text:
+        return resp.json()
+    return {}
+
+
+def list_projects(user: User.User):
+    return jira_api_request(user, "GET", "/rest/api/3/project/search")
+
+
+def create_issue(user: User.User, data: dict):
+    return jira_api_request(user, "POST", "/rest/api/3/issue", json=data)
+
+
+def search_issues(user: User.User, jql: str | None = None):
+    params = {"jql": jql} if jql else {}
+    return jira_api_request(user, "GET", "/rest/api/3/search", params=params)
+
+
+def update_issue(user: User.User, issue_id: str, data: dict):
+    return jira_api_request(user, "PUT", f"/rest/api/3/issue/{issue_id}", json=data)

--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -92,6 +92,13 @@ from RequestHandlers.Integration.GetIntegrationHandler import get_integration_ha
 from RequestHandlers.Integration.UpdateIntegrationHandler import update_integration_handler
 from RequestHandlers.Integration.DeleteIntegrationHandler import delete_integration_handler
 from RequestHandlers.Integration.GetIntegrationsHandler import get_integrations_handler
+from RequestHandlers.Jira.JiraHandlers import (
+    jira_auth_code_handler,
+    jira_projects_handler,
+    jira_create_issue_handler,
+    jira_get_issues_handler,
+    jira_update_issue_handler,
+)
 
 
 
@@ -339,6 +346,34 @@ handler_registry = {
     "/integrations": {
         "GET": {
             "handler": get_integrations_handler,
+            "public": False
+        }
+    },
+    "/jira-auth-code": {
+        "POST": {
+            "handler": jira_auth_code_handler,
+            "public": False
+        }
+    },
+    "/jira/projects": {
+        "GET": {
+            "handler": jira_projects_handler,
+            "public": False
+        }
+    },
+    "/jira/issues": {
+        "GET": {
+            "handler": jira_get_issues_handler,
+            "public": False
+        },
+        "POST": {
+            "handler": jira_create_issue_handler,
+            "public": False
+        }
+    },
+    "/jira/issues/{issue_id}": {
+        "POST": {
+            "handler": jira_update_issue_handler,
             "public": False
         }
     },


### PR DESCRIPTION
## Summary
- implement Jira service with token refresh and API helpers
- add Jira request handlers for auth code exchange and API proxy
- expose new Jira endpoints in the Lambda router

## Testing
- `PYTHONPATH=./src python -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_6849763e91b48327ac9ddefb2e956b33