### PR TITLE
Add Jira service functions and tools

### DIFF
--- a/src/Services/JiraService.py
+++ b/src/Services/JiraService.py
@@ -85,3 +85,30 @@ def search_issues(user: User.User, jql: str | None = None):
 
 def update_issue(user: User.User, issue_id: str, data: dict):
     return jira_api_request(user, "PUT", f"/rest/api/3/issue/{issue_id}", json=data)
+
+
+def transition_issue(user: User.User, issue_id: str, transition_id: str):
+    data = {"transition": {"id": transition_id}}
+    return jira_api_request(
+        user,
+        "POST",
+        f"/rest/api/3/issue/{issue_id}/transitions",
+        json=data,
+    )
+
+
+def assign_issue(user: User.User, issue_id: str, account_id: str):
+    data = {"accountId": account_id}
+    return jira_api_request(user, "PUT", f"/rest/api/3/issue/{issue_id}/assignee", json=data)
+
+
+def unassign_issue(user: User.User, issue_id: str):
+    return jira_api_request(user, "DELETE", f"/rest/api/3/issue/{issue_id}/assignee")
+
+
+def list_sprints(user: User.User, board_id: str):
+    return jira_api_request(user, "GET", f"/rest/agile/1.0/board/{board_id}/sprint")
+
+
+def get_sprint_issues(user: User.User, sprint_id: str):
+    return jira_api_request(user, "GET", f"/rest/agile/1.0/sprint/{sprint_id}/issue")

--- a/src/Tools/JiraTools.py
+++ b/src/Tools/JiraTools.py
@@ -1,0 +1,154 @@
+from pydantic import BaseModel, Field
+from LLM.AgentChat import AgentTool
+from Models import User
+from Services import JiraService
+import json
+
+
+class JiraCreateIssueParams(BaseModel):
+    project_key: str = Field(description="Key of the Jira project")
+    summary: str = Field(description="Issue summary")
+    description: str = Field(description="Issue description")
+    issue_type: str = Field(default="Task", description="Type of the issue")
+
+
+def jira_create_issue_func(project_key: str, summary: str, description: str, issue_type: str, context: dict) -> str:
+    try:
+        user = User.get_user(context["user_id"])
+        issue_data = {
+            "fields": {
+                "project": {"key": project_key},
+                "summary": summary,
+                "description": description,
+                "issuetype": {"name": issue_type},
+            }
+        }
+        res = JiraService.create_issue(user, issue_data)
+        return json.dumps(res)
+    except Exception as e:
+        return f"Error creating issue: {e}"
+
+
+jira_create_issue_tool = AgentTool(params=JiraCreateIssueParams, function=jira_create_issue_func, pass_context=True)
+
+
+class JiraSearchIssuesParams(BaseModel):
+    jql: str = Field(description="Jira Query Language string to search issues")
+
+
+def jira_search_issues_func(jql: str, context: dict) -> str:
+    try:
+        user = User.get_user(context["user_id"])
+        res = JiraService.search_issues(user, jql=jql)
+        return json.dumps(res)
+    except Exception as e:
+        return f"Error searching issues: {e}"
+
+
+jira_search_issues_tool = AgentTool(params=JiraSearchIssuesParams, function=jira_search_issues_func, pass_context=True)
+
+
+class JiraUpdateIssueParams(BaseModel):
+    issue_id: str = Field(description="ID or key of the issue to update")
+    summary: str | None = Field(default=None, description="Updated summary")
+    description: str | None = Field(default=None, description="Updated description")
+
+
+def jira_update_issue_func(issue_id: str, summary: str | None, description: str | None, context: dict) -> str:
+    try:
+        user = User.get_user(context["user_id"])
+        fields = {}
+        if summary is not None:
+            fields["summary"] = summary
+        if description is not None:
+            fields["description"] = description
+        data = {"fields": fields}
+        res = JiraService.update_issue(user, issue_id, data)
+        return json.dumps(res)
+    except Exception as e:
+        return f"Error updating issue: {e}"
+
+
+jira_update_issue_tool = AgentTool(params=JiraUpdateIssueParams, function=jira_update_issue_func, pass_context=True)
+
+
+class JiraTransitionIssueParams(BaseModel):
+    issue_id: str = Field(description="ID or key of the issue")
+    transition_id: str = Field(description="ID of the transition to apply")
+
+
+def jira_transition_issue_func(issue_id: str, transition_id: str, context: dict) -> str:
+    try:
+        user = User.get_user(context["user_id"])
+        res = JiraService.transition_issue(user, issue_id, transition_id)
+        return json.dumps(res)
+    except Exception as e:
+        return f"Error transitioning issue: {e}"
+
+
+jira_transition_issue_tool = AgentTool(params=JiraTransitionIssueParams, function=jira_transition_issue_func, pass_context=True)
+
+
+class JiraAssignIssueParams(BaseModel):
+    issue_id: str = Field(description="ID or key of the issue")
+    account_id: str = Field(description="Account ID of the assignee")
+
+
+def jira_assign_issue_func(issue_id: str, account_id: str, context: dict) -> str:
+    try:
+        user = User.get_user(context["user_id"])
+        res = JiraService.assign_issue(user, issue_id, account_id)
+        return json.dumps(res)
+    except Exception as e:
+        return f"Error assigning issue: {e}"
+
+
+jira_assign_issue_tool = AgentTool(params=JiraAssignIssueParams, function=jira_assign_issue_func, pass_context=True)
+
+
+class JiraUnassignIssueParams(BaseModel):
+    issue_id: str = Field(description="ID or key of the issue to unassign")
+
+
+def jira_unassign_issue_func(issue_id: str, context: dict) -> str:
+    try:
+        user = User.get_user(context["user_id"])
+        res = JiraService.unassign_issue(user, issue_id)
+        return json.dumps(res)
+    except Exception as e:
+        return f"Error unassigning issue: {e}"
+
+
+jira_unassign_issue_tool = AgentTool(params=JiraUnassignIssueParams, function=jira_unassign_issue_func, pass_context=True)
+
+
+class JiraGetSprintsParams(BaseModel):
+    board_id: str = Field(description="ID of the board to list sprints from")
+
+
+def jira_get_sprints_func(board_id: str, context: dict) -> str:
+    try:
+        user = User.get_user(context["user_id"])
+        res = JiraService.list_sprints(user, board_id)
+        return json.dumps(res)
+    except Exception as e:
+        return f"Error getting sprints: {e}"
+
+
+jira_get_sprints_tool = AgentTool(params=JiraGetSprintsParams, function=jira_get_sprints_func, pass_context=True)
+
+
+class JiraGetSprintIssuesParams(BaseModel):
+    sprint_id: str = Field(description="ID of the sprint to retrieve issues from")
+
+
+def jira_get_sprint_issues_func(sprint_id: str, context: dict) -> str:
+    try:
+        user = User.get_user(context["user_id"])
+        res = JiraService.get_sprint_issues(user, sprint_id)
+        return json.dumps(res)
+    except Exception as e:
+        return f"Error getting sprint issues: {e}"
+
+
+jira_get_sprint_issues_tool = AgentTool(params=JiraGetSprintIssuesParams, function=jira_get_sprint_issues_func, pass_context=True)

--- a/src/Tools/JiraTools.py
+++ b/src/Tools/JiraTools.py
@@ -6,10 +6,15 @@ import json
 
 
 class JiraCreateIssueParams(BaseModel):
-    project_key: str = Field(description="Key of the Jira project")
-    summary: str = Field(description="Issue summary")
-    description: str = Field(description="Issue description")
-    issue_type: str = Field(default="Task", description="Type of the issue")
+    """
+    Create a new Jira issue with specified details.
+    Use this tool when you need to create a task, bug, story or other issue type in a Jira project.
+    The issue will be created in the specified project with the provided summary and description.
+    """
+    project_key: str = Field(description="Key of the Jira project (e.g., 'PROJ', 'DEV')")
+    summary: str = Field(description="Brief summary or title of the issue")
+    description: str = Field(description="Detailed description of the issue, can include markdown formatting")
+    issue_type: str = Field(default="Task", description="Type of the issue (e.g., 'Task', 'Bug', 'Story', 'Epic')")
 
 
 def jira_create_issue_func(project_key: str, summary: str, description: str, issue_type: str, context: dict) -> str:
@@ -33,7 +38,17 @@ jira_create_issue_tool = AgentTool(params=JiraCreateIssueParams, function=jira_c
 
 
 class JiraSearchIssuesParams(BaseModel):
-    jql: str = Field(description="Jira Query Language string to search issues")
+    """
+    Search for Jira issues using JQL (Jira Query Language).
+    Use this tool to find existing issues matching specific criteria.
+    Results will include issue keys, summaries, and other basic information.
+    
+    Example JQL queries:
+    - project = "PROJ" AND status = "Open"
+    - assignee = currentUser() AND resolution = Unresolved
+    - created >= -30d AND project = "DEV"
+    """
+    jql: str = Field(description="Jira Query Language string to search issues (e.g., 'project = PROJ AND status = \"In Progress\"')")
 
 
 def jira_search_issues_func(jql: str, context: dict) -> str:
@@ -49,9 +64,14 @@ jira_search_issues_tool = AgentTool(params=JiraSearchIssuesParams, function=jira
 
 
 class JiraUpdateIssueParams(BaseModel):
-    issue_id: str = Field(description="ID or key of the issue to update")
-    summary: str | None = Field(default=None, description="Updated summary")
-    description: str | None = Field(default=None, description="Updated description")
+    """
+    Update an existing Jira issue's summary and/or description.
+    Use this tool to modify the details of an issue that already exists.
+    You can update either the summary, description, or both.
+    """
+    issue_id: str = Field(description="ID or key of the issue to update (e.g., 'PROJ-123')")
+    summary: str | None = Field(default=None, description="New summary text for the issue (leave as None to keep unchanged)")
+    description: str | None = Field(default=None, description="New description text for the issue (leave as None to keep unchanged)")
 
 
 def jira_update_issue_func(issue_id: str, summary: str | None, description: str | None, context: dict) -> str:
@@ -73,8 +93,13 @@ jira_update_issue_tool = AgentTool(params=JiraUpdateIssueParams, function=jira_u
 
 
 class JiraTransitionIssueParams(BaseModel):
-    issue_id: str = Field(description="ID or key of the issue")
-    transition_id: str = Field(description="ID of the transition to apply")
+    """
+    Change the status of a Jira issue by applying a workflow transition.
+    Use this tool to move issues between statuses (e.g., from "To Do" to "In Progress").
+    You'll need both the issue ID and the specific transition ID to apply.
+    """
+    issue_id: str = Field(description="ID or key of the issue (e.g., 'PROJ-123')")
+    transition_id: str = Field(description="ID of the transition to apply (use JiraSearchIssues first to find valid transition IDs)")
 
 
 def jira_transition_issue_func(issue_id: str, transition_id: str, context: dict) -> str:
@@ -90,8 +115,13 @@ jira_transition_issue_tool = AgentTool(params=JiraTransitionIssueParams, functio
 
 
 class JiraAssignIssueParams(BaseModel):
-    issue_id: str = Field(description="ID or key of the issue")
-    account_id: str = Field(description="Account ID of the assignee")
+    """
+    Assign a Jira issue to a specific user.
+    Use this tool when you need to allocate an issue to someone based on their account ID.
+    This will make the specified user the assignee of the issue.
+    """
+    issue_id: str = Field(description="ID or key of the issue (e.g., 'PROJ-123')")
+    account_id: str = Field(description="Account ID of the user to assign the issue to (e.g., '5b10a2844c20165700ede21g')")
 
 
 def jira_assign_issue_func(issue_id: str, account_id: str, context: dict) -> str:
@@ -107,7 +137,12 @@ jira_assign_issue_tool = AgentTool(params=JiraAssignIssueParams, function=jira_a
 
 
 class JiraUnassignIssueParams(BaseModel):
-    issue_id: str = Field(description="ID or key of the issue to unassign")
+    """
+    Remove the current assignee from a Jira issue.
+    Use this tool to clear the assignee field, making the issue unassigned.
+    This is useful when reassigning work or when the original assignee is no longer responsible.
+    """
+    issue_id: str = Field(description="ID or key of the issue to unassign (e.g., 'PROJ-123')")
 
 
 def jira_unassign_issue_func(issue_id: str, context: dict) -> str:
@@ -123,7 +158,12 @@ jira_unassign_issue_tool = AgentTool(params=JiraUnassignIssueParams, function=ji
 
 
 class JiraGetSprintsParams(BaseModel):
-    board_id: str = Field(description="ID of the board to list sprints from")
+    """
+    Retrieve all sprints from a specified Jira board.
+    Use this tool to get information about current, future, and past sprints in an Agile board.
+    Results include sprint names, start dates, end dates, and states.
+    """
+    board_id: str = Field(description="ID of the Jira board (e.g., '123')")
 
 
 def jira_get_sprints_func(board_id: str, context: dict) -> str:
@@ -139,7 +179,12 @@ jira_get_sprints_tool = AgentTool(params=JiraGetSprintsParams, function=jira_get
 
 
 class JiraGetSprintIssuesParams(BaseModel):
-    sprint_id: str = Field(description="ID of the sprint to retrieve issues from")
+    """
+    Retrieve all issues currently assigned to a specific sprint.
+    Use this tool to see what work is planned for or in progress in a particular sprint.
+    Results include all issues regardless of their current status.
+    """
+    sprint_id: str = Field(description="ID of the sprint to retrieve issues from (e.g., '456')")
 
 
 def jira_get_sprint_issues_func(sprint_id: str, context: dict) -> str:

--- a/src/Tools/ToolRegistry.py
+++ b/src/Tools/ToolRegistry.py
@@ -1,5 +1,23 @@
 from Tools.PassEvent import pass_event_tool
+from Tools.JiraTools import (
+    jira_create_issue_tool,
+    jira_search_issues_tool,
+    jira_update_issue_tool,
+    jira_transition_issue_tool,
+    jira_assign_issue_tool,
+    jira_unassign_issue_tool,
+    jira_get_sprints_tool,
+    jira_get_sprint_issues_tool,
+)
 
 tool_registry = {
     "pass_event": pass_event_tool,
+    "jira_create_issue": jira_create_issue_tool,
+    "jira_search_issues": jira_search_issues_tool,
+    "jira_update_issue": jira_update_issue_tool,
+    "jira_transition_issue": jira_transition_issue_tool,
+    "jira_assign_issue": jira_assign_issue_tool,
+    "jira_unassign_issue": jira_unassign_issue_tool,
+    "jira_get_sprints": jira_get_sprints_tool,
+    "jira_get_sprint_issues": jira_get_sprint_issues_tool,
 }


### PR DESCRIPTION
## Summary
- extend JiraService with actions for transitioning issues, assigning/unassigning issues and sprint queries
- implement JiraTools with agent tools for Jira actions
- register new Jira tools in ToolRegistry

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'AWS')*

------
https://chatgpt.com/codex/tasks/task_e_684a8cffec348327833fcd862a362723